### PR TITLE
Fix Wrong RegExp

### DIFF
--- a/index.js
+++ b/index.js
@@ -266,7 +266,7 @@
 
     Inko.prototype.is한글 = function (char) {
         if (char.length > 1) throw new Error("한 글자가 아닙니다.");
-        return /[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/.test(char);
+        return /[ㄱ-ㅎㅏ-ㅣ가-힣]/.test(char);
     }
 
     // CommonJS module


### PR DESCRIPTION
RegExp에서 CharacterSet은 | 태그 입력 시, '|'라는 Character로 인식하게 됩니다.